### PR TITLE
added functionality to view comments per article, with tests

### DIFF
--- a/__tests__/integrations.test.js
+++ b/__tests__/integrations.test.js
@@ -160,4 +160,39 @@ describe('Articles', () => {
         });
     });
   });
+  describe('GET /api/articles/:article_id/comments', () => {
+    test('GET 200: Endpoint returns all article comments from the specified article_id', () => {
+      return request(app)
+        .get('/api/articles/1/comments')
+        .expect(200)
+        .then(({ body: { comments } }) => {
+          const article_id = 1;
+          const expectedComment = {
+            comment_id: expect.any(Number),
+            article_id: expect.any(Number),
+            author: expect.any(String),
+            body: expect.any(String),
+            created_at: expect.any(String),
+            votes: expect.any(Number),
+          };
+          const isDescending = true;
+          expect(comments).toBeSortedBy('created_at', {
+            descending: isDescending,
+          });
+          comments.forEach((comment) => {
+            expect(comment.article_id).toBe(article_id);
+            expect(comment).toMatchObject(expectedComment);
+          });
+        });
+    });
+    test('GET 404: Endpoint returns error message when article has no comments', () => {
+      return request(app)
+        .get('/api/articles/2/comments')
+        .expect(404)
+        .then(({ body }) => {
+          const expectedResponse = 'Nothing to see here at the moment.';
+          expect(body.errorMessage).toBe(expectedResponse);
+        });
+    });
+  });
 });

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const {
 const {
   getArticleByID,
   getArticles,
+  getArticleComments,
 } = require('./controllers/articles.controller');
 
 const { sendGeneric404Error, sendErrorHandled } = require('./errors');
@@ -21,6 +22,8 @@ app.get('/api/topics', getTopics);
 app.get('/api/articles', getArticles);
 
 app.get('/api/articles/:article_id', getArticleByID);
+
+app.get('/api/articles/:article_id/comments', getArticleComments);
 
 app.use(sendErrorHandled);
 

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -1,6 +1,7 @@
 const {
   fetchArticleByID,
   fetchAllArticles,
+  fetchArticleComments,
 } = require('../models/articles.models');
 
 exports.getArticles = (req, res, next) => {
@@ -16,6 +17,15 @@ exports.getArticleByID = (req, res, next) => {
   return fetchArticleByID(article_id)
     .then((article) => {
       res.status(200).send({ article });
+    })
+    .catch((err) => next(err));
+};
+
+exports.getArticleComments = (req, res, next) => {
+  const { article_id } = req.params;
+  return fetchArticleComments(article_id)
+    .then((comments) => {
+      res.status(200).send({ comments });
     })
     .catch((err) => next(err));
 };

--- a/endpoints.json
+++ b/endpoints.json
@@ -41,5 +41,19 @@
         "comment_count": 6
       }
     }
+  },
+  "GET /api/articles/:article_id/comments": {
+    "description": "serves an array of objects containing the comments of the specified article",
+    "queries": ["article_id"],
+    "exampleResponse": {
+      "comments": {
+        "article_id": 1,
+        "comment_id": 1,
+        "author": "weegembump",
+        "body": "Comment on the article..",
+        "created_at": "2018-05-30T15:59:13.341Z",
+        "votes": 0
+      }
+    }
   }
 }

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -2,7 +2,7 @@ const db = require('../db/connection');
 
 // ERROR MESSAGES
 const recordNotFound = "Sorry! That particular record was not found"
-const recordsNotFound = 'Sorry! No records were found.';
+const recordsNotFound = 'Nothing to see here at the moment.';
 
 exports.fetchAllArticles = () => {
   const allArticlesByQuery = `SELECT a.article_id, a.title, a.topic, a.author, a.body, a.created_at, a.votes, a.article_img_url, COUNT(c.comment_id) as comment_count
@@ -17,8 +17,6 @@ exports.fetchAllArticles = () => {
   });
 };
 
-
-
 exports.fetchArticleByID = (articleID) => {
   const articleByIdQuery = `SELECT article_id, title, topic, author, body, created_at, votes, article_img_url FROM articles
   WHERE article_id = $1;`;
@@ -26,5 +24,16 @@ exports.fetchArticleByID = (articleID) => {
     if (!rows.length)
       return Promise.reject({ status: 404, errorMessage: recordNotFound });
     else return rows[0];
+  });
+};
+
+exports.fetchArticleComments = (articleID) => {
+  const commentsOfArticleQuery = `SELECT comment_id, votes, created_at, author, body, article_id FROM comments
+  WHERE article_id = $1
+  ORDER BY created_at desc`;
+  return db.query(commentsOfArticleQuery, [articleID]).then(({ rows }) => {
+    if (!rows.length)
+      return Promise.reject({ status: 404, errorMessage: recordsNotFound });
+    else return rows;
   });
 };


### PR DESCRIPTION
### added an endpoint for all the comments of an article (GET)
#### Details - Changelog/Changes:
* Added an endpoint for articles, displaying all comments for a given article
* Updated endpoint.json

#### Impact:
* Provides an a view of comments via descending order of created_at date (newest first)

#### Testing:
* Addition of 200 for endpoint.
* Include 404 test for an article with no comments.